### PR TITLE
Added CRT.SH support

### DIFF
--- a/arg_parser.py
+++ b/arg_parser.py
@@ -88,11 +88,17 @@ def get_args():
     # Parser
     parser = argparse.ArgumentParser(description="openSquat")
     parser.add_argument(
-        "-k", "--keywords", type=str, default="keywords.txt",
+        "-k",
+        "--keywords",
+        type=str,
+        default="keywords.txt",
         help="keywords file (default: keywords.txt)",
     )
     parser.add_argument(
-        "-o", "--output", type=str, default="results.txt",
+        "-o",
+        "--output",
+        type=str,
+        default="results.txt",
         help="output filename (default: results.txt)",
     )
     parser.add_argument(
@@ -101,30 +107,44 @@ def get_args():
         type=validate_confidence,
         default=1,
         help="0 (very high), 1 (high), 2 (medium), 3 (low),"
-             "4 (very low) (default: 1)",
+        "4 (very low) (default: 1)",
     )
     parser.add_argument(
-        "-t", "--type", type=validate_type, default="txt",
+        "-t",
+        "--type",
+        type=validate_type,
+        default="txt",
         help="output file type [txt|json|csv] (default: txt)",
     )
     parser.add_argument(
-        "-d", "--domains", type=str, default="",
+        "-d",
+        "--domains",
+        type=str,
+        default="",
         help="update from FILE instead of downloading new domains",
     )
     parser.add_argument(
-        "-p", "--period", type=validate_period, default="day",
+        "-p",
+        "--period",
+        type=validate_period,
+        default="day",
         help="Searchable period [day|week] (default: day)",
     )
 
     parser.add_argument(
-        "-m", "--method", type=str, choices=("Levenshtein", "JaroWinkler"),
+        "-m",
+        "--method",
+        type=str,
+        choices=("Levenshtein", "JaroWinkler"),
         default="Levenshtein",
-        help="method which is used to calculate similarity"
+        help="method which is used to calculate similarity",
     )
 
     parser.add_argument(
-        "--doppelganger_only", type=util.strtobool, default=False,
-        help="Find only doppelganger domains"
+        "--doppelganger_only",
+        type=util.strtobool,
+        default=False,
+        help="Find only doppelganger domains",
     )
 
     args = parser.parse_args()

--- a/ct.py
+++ b/ct.py
@@ -1,0 +1,69 @@
+""" Certificate transparency """
+import requests
+from bs4 import BeautifulSoup, NavigableString
+
+NOT_TRUSTED_CA = [
+    "Let's Encrypt Authority X3"
+]
+
+
+class CTLog:
+    def __init__(
+            self,
+            _id,
+            logget_at,
+            not_before,
+            not_after,
+            matching_ident,
+            issuer_name):
+        self._id = _id
+        self.logget_at = logget_at
+        self.not_before = not_before
+        self.not_after = not_after
+        self.matching_ident = matching_ident
+        self.issuer_name = issuer_name
+
+
+class CRTSH:
+    """ Class responsible for checking given domain for CT logs """
+    URL = "https://crt.sh/"
+
+    @classmethod
+    def check_certificate(cls, domain: str) -> bool:
+        url = f"{cls.URL}?q={domain}"
+
+        try:
+            html_text = requests.get(url).text
+        except Exception as e:
+            print("Cannot fetch data from {url}")
+            return True
+
+        soup = BeautifulSoup(html_text, 'html.parser')
+
+        collected_logs = []
+        for table in soup.find_all('table')[1]:
+            if isinstance(table, NavigableString):
+                continue
+
+            for table_row in table.find_all('tr')[1:]:
+                tds = [td for td in table_row.find_all("td")]
+                collected_logs.append(
+                    CTLog(
+                        tds[0].text,
+                        tds[1].text,
+                        tds[2].text,
+                        tds[3].text,
+                        [x for x in tds[4] if isinstance(x, NavigableString)],
+                        tds[5].text)
+                )
+
+        for ca in NOT_TRUSTED_CA:
+            for ctlog in collected_logs:
+                if domain in ctlog.matching_ident:  # checking domain matching
+                    if ca in ctlog.issuer_name:  # checking CA
+                        return False
+
+        if not collected_logs:
+            return False
+
+        return True

--- a/ct.py
+++ b/ct.py
@@ -2,20 +2,13 @@
 import requests
 from bs4 import BeautifulSoup, NavigableString
 
-NOT_TRUSTED_CA = [
-    "Let's Encrypt Authority X3"
-]
+NOT_TRUSTED_CA = ["Let's Encrypt Authority X3"]
 
 
 class CTLog:
     def __init__(
-            self,
-            _id,
-            logget_at,
-            not_before,
-            not_after,
-            matching_ident,
-            issuer_name):
+        self, _id, logget_at, not_before, not_after, matching_ident, issuer_name
+    ):
         self._id = _id
         self.logget_at = logget_at
         self.not_before = not_before
@@ -26,6 +19,7 @@ class CTLog:
 
 class CRTSH:
     """ Class responsible for checking given domain for CT logs """
+
     URL = "https://crt.sh/"
 
     @classmethod
@@ -38,14 +32,14 @@ class CRTSH:
             print("Cannot fetch data from {url}")
             return True
 
-        soup = BeautifulSoup(html_text, 'html.parser')
+        soup = BeautifulSoup(html_text, "html.parser")
 
         collected_logs = []
-        for table in soup.find_all('table')[1]:
+        for table in soup.find_all("table")[1]:
             if isinstance(table, NavigableString):
                 continue
 
-            for table_row in table.find_all('tr')[1:]:
+            for table_row in table.find_all("tr")[1:]:
                 tds = [td for td in table_row.find_all("td")]
                 collected_logs.append(
                     CTLog(
@@ -54,7 +48,8 @@ class CRTSH:
                         tds[2].text,
                         tds[3].text,
                         [x for x in tds[4] if isinstance(x, NavigableString)],
-                        tds[5].text)
+                        tds[5].text,
+                    )
                 )
 
         for ca in NOT_TRUSTED_CA:

--- a/opensquat.py
+++ b/opensquat.py
@@ -48,8 +48,10 @@ class Domain:
     """
 
     def __init__(self):
-        self.URL = "https://raw.githubusercontent.com/CERT-MZ/projects" \
-                   "/master/Domain-squatting/"
+        self.URL = (
+            "https://raw.githubusercontent.com/CERT-MZ/projects"
+            "/master/Domain-squatting/"
+        )
         self.URL_file = None
         self.today = date.today().strftime("%Y-%m-%d")
         self.domain_filename = None
@@ -73,7 +75,7 @@ class Domain:
             0.8: "Low",
             0.89: "Medium",
             0.949: "High",
-            0.95: "Very high"
+            0.95: "Very high",
         }
 
         self.method = "Levenshtein"
@@ -107,7 +109,7 @@ class Domain:
         response = requests.get(URL, stream=True)
 
         # Get total file size in bytes from the request header
-        total_size = int(response.headers.get('content-length', 0))
+        total_size = int(response.headers.get("content-length", 0))
         total_size_mb = round(float(total_size / 1024 / 1024), 2)
 
         print("[*] Download volume:", total_size_mb, "MB")
@@ -136,8 +138,9 @@ class Domain:
 
         if not os.path.isfile(self.domain_filename):
             print(
-                "[*] File", self.domain_filename, "not found or not readable!"
-                                                  "Exiting...\n",
+                "[*] File",
+                self.domain_filename,
+                "not found or not readable!" "Exiting...\n",
             )
             exit(-1)
 
@@ -159,14 +162,19 @@ class Domain:
 
         if not os.path.isfile(self.keywords_filename):
             print(
-                "[*] File", self.keywords_filename, "not found or not"
-                                                    "readable! Exiting... \n"
+                "[*] File",
+                self.keywords_filename,
+                "not found or not" "readable! Exiting... \n",
             )
             exit(-1)
 
         for line in open(self.keywords_filename):
-            if (line[0] != "#") and (line[0] != " ") and (line[0] != "") and \
-               (line[0] != "\n"):
+            if (
+                (line[0] != "#")
+                and (line[0] != " ")
+                and (line[0] != "")
+                and (line[0] != "\n")
+            ):
                 self.keywords_total += 1
 
     def set_filename(self, filename):
@@ -230,8 +238,12 @@ class Domain:
             if not keyword:
                 continue
 
-            if ((keyword[0] != "#") and (keyword[0] != " ") and
-                    (keyword[0] != "") and (keyword[0] != "\n")):
+            if (
+                (keyword[0] != "#")
+                and (keyword[0] != " ")
+                and (keyword[0] != "")
+                and (keyword[0] != "\n")
+            ):
                 i += 1
                 print(
                     Fore.GREEN + "\n[*] Verifying keyword:",
@@ -258,24 +270,26 @@ class Domain:
                         domain = homograph.homograph_to_latin(domain)
 
                     if self.doppelganger_only:
-                        self._process_doppelgagner_only(
-                            keyword, domain, domains
-                        )
+                        self._process_doppelgagner_only(keyword, domain, domains)
 
                         continue
 
                     if self.method.lower() == "levenshtein":
-                        self._process_levenshtein(keyword, domain,
-                                                  homograph_domain, domains)
-                    elif self.method.lower() == 'jarowinkler':
-                        self._process_jarowinkler(keyword, domain,
-                                                  homograph_domain, domains)
+                        self._process_levenshtein(
+                            keyword, domain, homograph_domain, domains
+                        )
+                    elif self.method.lower() == "jarowinkler":
+                        self._process_jarowinkler(
+                            keyword, domain, homograph_domain, domains
+                        )
                     else:
-                        print(f"No such method: {self.method}. "
-                              "Levenshtein will be used as default."
-                              )
-                        self._process_levenshtein(keyword, domain,
-                                                  homograph_domain, domains)
+                        print(
+                            f"No such method: {self.method}. "
+                            "Levenshtein will be used as default."
+                        )
+                        self._process_levenshtein(
+                            keyword, domain, homograph_domain, domains
+                        )
 
             f_dom.seek(0)
 
@@ -308,12 +322,10 @@ class Domain:
         leven_dist = validations.levenshtein(keyword, domain)
 
         if (leven_dist <= self.confidence_level) and not homograph_domain:
-            self.on_similarity_detected(keyword, domains,
-                                        self.confidence[leven_dist])
+            self.on_similarity_detected(keyword, domains, self.confidence[leven_dist])
 
         elif (leven_dist <= self.confidence_level) and homograph_domain:
-            self.on_homograph_detected(keyword, domains,
-                                       self.confidence[leven_dist])
+            self.on_homograph_detected(keyword, domains, self.confidence[leven_dist])
 
         elif self.domain_contains(keyword, domains):
             self.on_domain_contains(keyword, domains)
@@ -362,13 +374,23 @@ class Domain:
 
     def on_domain_contains(self, keyword, domains):
         print(
-            Fore.YELLOW + "[+] The word", keyword, "is contained in",
-                          domains, "" + Style.RESET_ALL,
+            Fore.YELLOW + "[+] The word",
+            keyword,
+            "is contained in",
+            domains,
+            "" + Style.RESET_ALL,
         )
         self.list_domains.append(domains)
 
-    def main(self, keywords_file, confidence_level, domains_file,
-             search_period, method, doppelganger_only=False):
+    def main(
+        self,
+        keywords_file,
+        confidence_level,
+        domains_file,
+        search_period,
+        method,
+        doppelganger_only=False,
+    ):
         """Method to call the class functions
 
         Args:
@@ -409,7 +431,8 @@ if __name__ == "__main__":
     )
 
     logo = (
-        Fore.GREEN + """
+        Fore.GREEN
+        + """
                                              █████████                                  █████
                                             ███░░░░░███                                ░░███
       ██████  ████████   ██████  ████████  ░███    ░░░   ████████ █████ ████  ██████   ███████
@@ -422,7 +445,8 @@ if __name__ == "__main__":
               █████                                         █████
              ░░░░░                                         ░░░░░
                     (c) CERT-MZ | Andre Tenreiro | andre@cert.mz
-    """ + Style.RESET_ALL
+    """
+        + Style.RESET_ALL
     )
 
     print(logo)
@@ -432,8 +456,12 @@ if __name__ == "__main__":
 
     start_time = time.time()
     file_content = Domain().main(
-        args.keywords, args.confidence, args.domains,
-        args.period, args.method, args.doppelganger_only
+        args.keywords,
+        args.confidence,
+        args.domains,
+        args.period,
+        args.method,
+        args.doppelganger_only,
     )
 
     print("")

--- a/output.py
+++ b/output.py
@@ -60,8 +60,9 @@ class SaveFile:
             none
         """
         f_csv = open(self.filename, "w")
-        file_csv = csv.writer(f_csv, delimiter=",", quotechar='"',
-                              quoting=csv.QUOTE_MINIMAL)
+        file_csv = csv.writer(
+            f_csv, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
+        )
         file_csv.writerow(self.content)
         file_csv.close()
         print("[*] file saved:", self.filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ codecov
 coverage
 black
 flake8
+beautifulsoup4

--- a/tests/test_ct.py
+++ b/tests/test_ct.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+from ct import CRTSH
+
+
+class TestCRTSH(TestCase):
+    def test_malicious_domains(self):
+        self.assertFalse(CRTSH.check_certificate("facebookcontentmontorsettlement.com"))
+        self.assertFalse(CRTSH.check_certificate("verifiedsfromfacebook.com"))
+        self.assertFalse(CRTSH.check_certificate("user-login-facebook.com"))
+        self.assertFalse(CRTSH.check_certificate("googlecloudarchitecture.com"))
+
+    def test_valid_domains(self):
+        self.assertTrue(CRTSH.check_certificate("facebook.com"))
+        self.assertTrue(CRTSH.check_certificate("paypal.com"))
+        self.assertTrue(CRTSH.check_certificate("netflix.com"))
+        self.assertTrue(CRTSH.check_certificate("google.com"))
+
+    def test_certificates_not_found(self):
+        self.assertFalse(CRTSH.check_certificate("escortgooglee.com"))

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -10,6 +10,3 @@ class TestValidations(TestCase):
     def test_levenshtein(self):
         self.assertEqual(7, levenshtein("netflix", "netflix123.com"))
         self.assertEqual(16, levenshtein("netflix", "888888888888.com"))
-
-    def test_mine(self):
-        self.assertEqual(16, jaro_winkler("something", "gmosehitt"))

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -10,3 +10,6 @@ class TestValidations(TestCase):
     def test_levenshtein(self):
         self.assertEqual(7, levenshtein("netflix", "netflix123.com"))
         self.assertEqual(16, levenshtein("netflix", "888888888888.com"))
+
+    def test_mine(self):
+        self.assertEqual(16, jaro_winkler("something", "gmosehitt"))


### PR DESCRIPTION
Added functionality which search analyzed domain in crt.sh for logs. If not trusted CA is found then proper information is printed. 

This functionality is now implemented in `--doppelganger-only`.  